### PR TITLE
meta: run lints and tests in github actions

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -10,7 +10,9 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install qemu
-        run: sudo apt-get install qemu --fix-missing
+        run: |
+          sudo apt-get update
+          sudo apt-get install qemu
 
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Install qemu
         run: |
           sudo apt-get update
-          sudo apt-get install qemu-system-x86_64
+          sudo apt-get install qemu-system-x86
       - name: Install the rust toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -1,0 +1,24 @@
+on: [push, pull_request]
+
+name: Lints
+
+jobs:
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+          components: rustfmt, clippy, bootimage, cargo-xbuild
+      - name: Fetch additional rustup components
+        run: |
+          rustup component add rust-src --toolchain=nightly
+          rustup component add llvm-tools-preview --toolchain=nightly
+      - name: Rustfmt
+        run: cargo fmt -- --check
+      - name: Clippy
+        run: cargo xclippy -- -D warnings

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -1,35 +1,39 @@
 on: [push, pull_request]
 
-name: Lints
+name: Lints and tests
 
 jobs:
-  clippy:
-    name: Clippy
+  tests:
+    name: Lints and tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: docker/setup-qemu-action@v1
-        with:
-          image: tonistiigi/binfmt:latest
-          platforms: all
-      - name: Available platforms
-        run: echo ${{ steps.qemu.outputs.platforms }}
-      - run: qemu-system-x86_64 --version
+
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: nightly
           override: true
           components: rustfmt, clippy
+
       - name: Fetch additional cargo components
         run: |
           cargo install bootimage
           cargo install cargo-xbuild
+
       - name: Fetch additional rustup components
         run: |
           rustup component add rust-src --toolchain=nightly
           rustup component add llvm-tools-preview --toolchain=nightly
+
+      - name: Install qemu
+        run: apt-get install qemu
+
       - name: Rustfmt
         run: cargo fmt -- --check
+
       - name: Clippy
         run: cargo xclippy -- -D warnings
+
+      - name: Run tests
+        run: cargo xtest

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -8,6 +8,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: docker/setup-qemu-action@v1
+        with:
+          image: tonistiigi/binfmt:latest
+          platforms: all
+      - name: Available platforms
+        run: echo ${{ steps.qemu.outputs.platforms }}
+      - run: qemu-system-x86_64 --version
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -8,34 +8,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-
       - name: Install qemu
         run: |
           sudo apt-get update
-          sudo apt-get install qemu
-
-      - uses: actions-rs/toolchain@v1
+          sudo apt-get install qemu-system-x86_64
+      - name: Install the rust toolchain
+        uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: nightly
           override: true
           components: rustfmt, clippy
-
-      - name: Fetch additional cargo components
+      - name: Fetch additional rust components
         run: |
           cargo install bootimage
           cargo install cargo-xbuild
-
-      - name: Fetch additional rustup components
-        run: |
           rustup component add rust-src --toolchain=nightly
           rustup component add llvm-tools-preview --toolchain=nightly
 
-      - name: Rustfmt
+      # The actual lints and tests
+      - name: fmt
         run: cargo fmt -- --check
-
-      - name: Clippy
+      - name: clippy
         run: cargo xclippy -- -D warnings
-
-      - name: Run tests
+      - name: tests
         run: cargo xtest

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -27,7 +27,7 @@ jobs:
           rustup component add llvm-tools-preview --toolchain=nightly
 
       - name: Install qemu
-        run: apt-get install qemu
+        run: sudo apt-get install qemu
 
       - name: Rustfmt
         run: cargo fmt -- --check

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -13,7 +13,11 @@ jobs:
           profile: minimal
           toolchain: nightly
           override: true
-          components: rustfmt, clippy, bootimage, cargo-xbuild
+          components: rustfmt, clippy
+      - name: Fetch additional cargo components
+        run: |
+          cargo install bootimage
+          cargo install cargo-xbuild
       - name: Fetch additional rustup components
         run: |
           rustup component add rust-src --toolchain=nightly

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -18,13 +18,12 @@ jobs:
           profile: minimal
           toolchain: nightly
           override: true
-          components: rustfmt, clippy
+          default: true
+          components: rustfmt, clippy, bootimage, cargo-xbuild
       - name: Fetch additional rust components
         run: |
-          cargo install bootimage
-          cargo install cargo-xbuild
-          rustup component add rust-src --toolchain=nightly
-          rustup component add llvm-tools-preview --toolchain=nightly
+          rustup component add rust-src
+          rustup component add llvm-tools-preview
 
       # The actual lints and tests
       - name: fmt
@@ -32,4 +31,4 @@ jobs:
       - name: clippy
         run: cargo xclippy -- -D warnings
       - name: tests
-        run: cargo xtest
+        run: cargo xtest 2> /dev/null

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -9,6 +9,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Install qemu
+        run: sudo apt-get install qemu --fix-missing
+
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -25,9 +28,6 @@ jobs:
         run: |
           rustup component add rust-src --toolchain=nightly
           rustup component add llvm-tools-preview --toolchain=nightly
-
-      - name: Install qemu
-        run: sudo apt-get install qemu
 
       - name: Rustfmt
         run: cargo fmt -- --check

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -3,17 +3,12 @@ on: [push, pull_request]
 name: Lints and tests
 
 jobs:
-  tests:
+  lints-and-tests:
     name: Lints and tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install qemu
-        run: |
-          sudo apt-get update
-          sudo apt-get install qemu-system-x86
-      - name: Install the rust toolchain
-        uses: actions-rs/toolchain@v1
+      - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           components: rustfmt, clippy
@@ -23,11 +18,16 @@ jobs:
           cargo install cargo-xbuild
           rustup component add rust-src
           rustup component add llvm-tools-preview
+      - name: Install qemu
+        run: |
+          sudo apt-get update
+          sudo apt-get install qemu-system-x86
 
-      # The actual lints and tests
       - name: fmt
         run: cargo fmt -- --check
       - name: clippy
-        run: cargo xclippy -- -D warnings
+        run: |
+          touch src/**/*.rs
+          cargo xclippy -- -D warnings
       - name: tests
         run: cargo xtest 2> /dev/null

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -16,12 +16,11 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
-          override: true
-          default: true
-          components: rustfmt, clippy, bootimage, cargo-xbuild
+          components: rustfmt, clippy
       - name: Fetch additional rust components
         run: |
+          cargo install bootimage
+          cargo install cargo-xbuild
           rustup component add rust-src
           rustup component add llvm-tools-preview
 


### PR DESCRIPTION
## Description
Adds github actions to this project! GH Actions is free for all public repos so why not? Since this project requires some custom tooling, like custom rust build toolchains and qemu, it as slightly more complicated to get going than I imagined but got it working.

Runs rustfmt, clippy, and all tests 🎉 

---

Did this in a PR to be able to test the action, which you cannot do locally, without spamming commits in the master branch.