### PR TITLE
meta: cache ./target in github actions

### DIFF
--- a/.github/workflows/lints-and-tests.yml
+++ b/.github/workflows/lints-and-tests.yml
@@ -12,10 +12,10 @@ jobs:
         with:
           path: |
             target
-            ${{ env.CARGO_HOME }}/bin/
-            ${{ env.CARGO_HOME }}/registry/index/
-            ${{ env.CARGO_HOME }}/registry/cache/
-            ${{ env.CARGO_HOME }}/git/db/
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
           key: v1-build-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             v1-build-

--- a/.github/workflows/lints-and-tests.yml
+++ b/.github/workflows/lints-and-tests.yml
@@ -10,10 +10,15 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/cache@v1.0.1
         with:
-          path: target
-          key: v1-${{ runner.OS }}-build-${{ hashFiles('**/Cargo.lock') }}
+          path: |
+            target
+            $CARGO_HOME/bin/
+            $CARGO_HOME/registry/index/
+            $CARGO_HOME/registry/cache/
+            $CARGO_HOME/git/db/
+          key: v1-build-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            v1-${{ runner.OS }}-build-
+            v1-build-
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/.github/workflows/lints-and-tests.yml
+++ b/.github/workflows/lints-and-tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v1.0.1
+      - uses: actions/cache@v2
         with:
           path: |
             target
@@ -34,7 +34,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install qemu-system-x86
 
-      - run: echo $CARGO_HOME
+      - run: |
+        find / ".cargo"
       - name: fmt
         run: cargo fmt -- --check
       - name: clippy

--- a/.github/workflows/lints-and-tests.yml
+++ b/.github/workflows/lints-and-tests.yml
@@ -8,6 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/cache@v1.0.1
+        with:
+          path: target
+          key: v1-${{ runner.OS }}-build-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            v1-${{ runner.OS }}-build-
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/.github/workflows/lints-and-tests.yml
+++ b/.github/workflows/lints-and-tests.yml
@@ -34,8 +34,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install qemu-system-x86
 
-      - run: |
-        find / ".cargo"
       - name: fmt
         run: cargo fmt -- --check
       - name: clippy

--- a/.github/workflows/lints-and-tests.yml
+++ b/.github/workflows/lints-and-tests.yml
@@ -34,6 +34,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install qemu-system-x86
 
+      - run: echo $CARGO_HOME
       - name: fmt
         run: cargo fmt -- --check
       - name: clippy

--- a/.github/workflows/lints-and-tests.yml
+++ b/.github/workflows/lints-and-tests.yml
@@ -12,10 +12,10 @@ jobs:
         with:
           path: |
             target
-            $CARGO_HOME/bin/
-            $CARGO_HOME/registry/index/
-            $CARGO_HOME/registry/cache/
-            $CARGO_HOME/git/db/
+            ${{ env.CARGO_HOME }}/bin/
+            ${{ env.CARGO_HOME }}/registry/index/
+            ${{ env.CARGO_HOME }}/registry/cache/
+            ${{ env.CARGO_HOME }}/git/db/
           key: v1-build-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             v1-build-

--- a/.github/workflows/lints-and-tests.yml
+++ b/.github/workflows/lints-and-tests.yml
@@ -25,8 +25,8 @@ jobs:
           components: rustfmt, clippy
       - name: Fetch additional rust components
         run: |
-          cargo install bootimage
-          cargo install cargo-xbuild
+          cargo install bootimage || true
+          cargo install cargo-xbuild || true
           rustup component add rust-src
           rustup component add llvm-tools-preview
       - name: Install qemu


### PR DESCRIPTION
Caches the `target` folder to avoid a lot of recompliation, as well as the cargo folders which they [officially recommend](https://doc.rust-lang.org/cargo/guide/cargo-home.html#caching-the-cargo-home-in-ci) you cache in ci.

### Before 4 min, 10s
![image](https://user-images.githubusercontent.com/23080686/91205785-65aedc80-e706-11ea-947f-79d3beee27e3.png)

### After 1 min, 28s 🎉 
![image](https://user-images.githubusercontent.com/23080686/91205801-6e9fae00-e706-11ea-89ce-7f2dd4523ee6.png)
