### PR TITLE
meta: fix and simplify github actions config

### DIFF
--- a/.github/workflows/lints-and-tests.yml
+++ b/.github/workflows/lints-and-tests.yml
@@ -16,8 +16,8 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-          key: v1-build-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: v1-build-
+          key: v2-build-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: v2-build-
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/.github/workflows/lints-and-tests.yml
+++ b/.github/workflows/lints-and-tests.yml
@@ -17,19 +17,16 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
           key: v1-build-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            v1-build-
+          restore-keys: v1-build-
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           components: rustfmt, clippy, rust-src, llvm-tools-preview
-      - name: Install bootimage tool
-        run: cargo install bootimage || true
-      - name: Install qemu
+      - name: Install additional tools
         run: |
+          cargo install bootimage
           sudo apt-get update
           sudo apt-get install qemu-system-x86
-
       - name: fmt
         run: cargo fmt -- --check
       - name: clippy

--- a/.github/workflows/lints-and-tests.yml
+++ b/.github/workflows/lints-and-tests.yml
@@ -22,12 +22,9 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          components: rustfmt, clippy
-      - name: Fetch additional rust components
-        run: |
-          cargo install bootimage || true
-          rustup component add rust-src
-          rustup component add llvm-tools-preview
+          components: rustfmt, clippy, rust-src, llvm-tools-preview
+      - name: Install bootimage tool
+        run: cargo install bootimage || true
       - name: Install qemu
         run: |
           sudo apt-get update

--- a/.github/workflows/lints-and-tests.yml
+++ b/.github/workflows/lints-and-tests.yml
@@ -24,7 +24,7 @@ jobs:
           components: rustfmt, clippy, rust-src, llvm-tools-preview
       - name: Install additional tools
         run: |
-          cargo install bootimage
+          cargo +stable install bootimage
           sudo apt-get update
           sudo apt-get install qemu-system-x86
       - name: fmt

--- a/.github/workflows/lints-and-tests.yml
+++ b/.github/workflows/lints-and-tests.yml
@@ -24,7 +24,7 @@ jobs:
           components: rustfmt, clippy, rust-src, llvm-tools-preview
       - name: Install additional tools
         run: |
-          cargo +stable install bootimage
+          cargo +stable install bootimage || true
           sudo apt-get update
           sudo apt-get install qemu-system-x86
       - name: fmt

--- a/setup.sh
+++ b/setup.sh
@@ -24,10 +24,10 @@ else
 fi
 
 # Builds bootable images from rust source
-if bootimage --help > /dev/null 2>&1 ; then
+if bootimage --version > /dev/null 2>&1 ; then
   echo "Already installed: bootimage"
 else
-  cargo install bootimage || fail "bootimage"
+  cargo +stable install bootimage || fail "bootimage"
 fi
 
 # Source files for rust core, needed to compile core to our custom target


### PR DESCRIPTION
After 917dfc48 we now use the built-in cargo features only to compile the OS. This however meant when trying to do `cargo install` it will use the nightly version and therefore append `-Zbuild-std` with fails since no target is supplied with install.

So we explicitly use `+stable` when installing bootimage.

Also simplified the config a bit.